### PR TITLE
Add Dockerfile & k8s CronJob YAML

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM scratch
+COPY cni-k8s-tool .
+CMD ["/cni-k8s-tool"]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # amazon-vpc-cni-k8s-tool
 amazon-vpc-cni-k8s-tool for IP garbage collection
 
- ./cni-k8s-tool ip-gc --free-after=1s
+## Prerequisites
 
 Requires below IAM permissions:
 
@@ -18,3 +18,21 @@ Requires below IAM permissions:
     ]
 }
 ```
+
+## Usage
+
+ ./cni-k8s-tool list-free-IPs
+
+ ./cni-k8s-tool registry-list
+
+ ./cni-k8s-tool ip-gc --free-after=1s
+
+## K8s native installation
+
+A Dockerfile and K8s CronJob kubeyaml manifest is provided.
+
+Build the Dockerfile and push to an image registry, then update the 'image:' in cni-k8s-tool_ip-gc_cron.yaml
+
+Applying cni-k8s-tool_ip-gc_cron.yaml will create a CronJob in the kube-system namespace that runs the `./cni-k8s-tool ip-gc --free-after=1s` from above every minute.
+
+Note: 'Completed' Jobs have been observed to pile up in the `kubectl get pods -n kube-system` output. Tools such as [onfido/k8s-cleanup](https://github.com/onfido/k8s-cleanup ) may also be desirable to clean those up.

--- a/cni-k8s-tool_ip-gc_cron.yaml
+++ b/cni-k8s-tool_ip-gc_cron.yaml
@@ -1,0 +1,23 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: cni-k8s-tool-ip-gc
+  namespace: kube-system
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            k8s-app: cni-k8s-tool-ip-gc
+        spec:
+          containers:
+          - name: cni-k8s-tool
+            image: cni-k8s-tool:v0.1
+            imagePullPolicy: Always
+            args:
+            - /cni-k8s-tool
+            - ip-gc
+            - --free-after=1s
+          restartPolicy: Never


### PR DESCRIPTION
Since this app is a golang app, it is pretty trivial to put it in a scratch image and run the cleanup on a schedule (once a minute) with a K8s CronJob.

I do not plan to publish an image, instructions are to build yourself and change the image pull location.

Note:
*   imagePullPolicy is Always, so that new jobs always pull the latest version even if cached on the instance - running once a minute does cause additional load on the image registry, so that can be removed to go back to the default.
*   restartPolicy is Never, as it would instead be desirable to run a new job on a different host a minute later, rather than trying to restart on the same node (which may already have IP issues preventing it from running pods, etc).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.